### PR TITLE
custom timeout for jupyterlab splash screen

### DIFF
--- a/src/JupyterLibrary/clients/jupyterlab/Shell.robot
+++ b/src/JupyterLibrary/clients/jupyterlab/Shell.robot
@@ -22,10 +22,10 @@ Open JupyterLab
     Tag With JupyterLab Metadata    ${pageinfo tags}    clear=${clear}
 
 Wait for JupyterLab Splash Screen
-    [Arguments]    ${custom_timeout}=10s
+    [Arguments]    ${timeout}=10s
     [Documentation]    Wait for the JupyterLab splash animation
-    Wait Until Page Contains Element    css:#${JLAB ID SPLASH}    timeout=${custom_timeout}
-    Wait Until Page Does Not Contain Element    css:#${JLAB ID SPLASH}    timeout=${custom_timeout}
+    Wait Until Page Contains Element    css:#${JLAB ID SPLASH}    timeout=${timeout}
+    Wait Until Page Does Not Contain Element    css:#${JLAB ID SPLASH}    timeout=${timeout}
     Sleep    2s
 
 Click JupyterLab Menu

--- a/src/JupyterLibrary/clients/jupyterlab/Shell.robot
+++ b/src/JupyterLibrary/clients/jupyterlab/Shell.robot
@@ -22,9 +22,10 @@ Open JupyterLab
     Tag With JupyterLab Metadata    ${pageinfo tags}    clear=${clear}
 
 Wait for JupyterLab Splash Screen
+    [Arguments]    ${custom_timeout}=10s
     [Documentation]    Wait for the JupyterLab splash animation
-    Wait Until Page Contains Element    css:#${JLAB ID SPLASH}    timeout=10s
-    Wait Until Page Does Not Contain Element    css:#${JLAB ID SPLASH}    timeout=10s
+    Wait Until Page Contains Element    css:#${JLAB ID SPLASH}    timeout=${custom_timeout}
+    Wait Until Page Does Not Contain Element    css:#${JLAB ID SPLASH}    timeout=${custom_timeout}
     Sleep    2s
 
 Click JupyterLab Menu


### PR DESCRIPTION
With this PR I would like to add the option of having a custom timeout for the `Wait for JupyterLab Splash Screen` keyword rather than being forced to use the default 10 seconds.