### PR TITLE
ci: allow ci workflow to be manually triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
This PR enables the CI workflow to run manually by the click of a button (by repo maintainers).

## Example of the button from another repo

![image](https://user-images.githubusercontent.com/3837114/210074143-0ff479c4-59c8-4c3a-bc8d-e25c49fa2dbe.png)
